### PR TITLE
Contextmanager

### DIFF
--- a/jobs/add.py.cfg
+++ b/jobs/add.py.cfg
@@ -1,0 +1,4 @@
+[aws]
+instance_type: m1.small
+product_description: Linux/UNIX
+ami: ami-2511234c

--- a/jobs/grind.cfg
+++ b/jobs/grind.cfg
@@ -1,10 +1,11 @@
 [aws]
 instance_type: m1.small
 product_description: Linux/UNIX
-ami: ami-e944d9d3
+# ami: ami-e944d9d3
+ami: ami-2511234c
 key_name: grind
 security_group: grind
 
-[ssh]
-before:
-    sudo apt-get -y install python-psycopg2
+# [ssh]
+# before:
+#    sudo apt-get -y install python-psycopg2


### PR DESCRIPTION
One with statement = many nested context managers because it looks neater that way.

Job specific config rather than global grind.cfg because it seems more flexible.
